### PR TITLE
Update main_mockinterviewapp-backend-takashi01.yml

### DIFF
--- a/.github/workflows/main_mockinterviewapp-backend-takashi01.yml
+++ b/.github/workflows/main_mockinterviewapp-backend-takashi01.yml
@@ -44,11 +44,11 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     environment:
-      name: 'Production'
+      name: 'Production' # This environment name must exactly match the "GitHub environment name" you configured in Azure Federated Credentials.
       url: ${{ steps.deploy-to-webapp.outputs.webapp-url }}
     permissions:
-      id-token: write # This is required for requesting the JWT
-      contents: read # This is required for actions/checkout
+      id-token: write # This permission is crucial for OpenID Connect (OIDC) authentication.
+      contents: read
     steps:
       - name: Download artifact from build job
         uses: actions/download-artifact@v4
@@ -59,10 +59,11 @@ jobs:
       - name: Login to Azure
         uses: azure/login@v2
         with:
-          client-id: ${{ secrets.AZUREAPPSERVICE_CLIENTID_DE95F72921FA45E9B291A934DD6F6ED75 }}
-          tenant-id: ${{ secrets.AZUREAPPSERVICE_TENANTID_3D8C02EEC437468194CDE7242E06C6E5 }}
-          subscription-id: ${{ secrets.AZUREAPPSERVICE_SUBSCRIPTIONID_2893712FC95E4564961A934DD6F6ED75 }}
-          client-secret: ${{ secrets.AZUREAPPSERVICE_CLIENT_SECRET }} # THIS IS THE CRITICAL LINE ADDED!
+          # For OIDC authentication (due to 'id-token: write' permission),
+          # 'client-id', 'tenant-id', and 'client-secret' are NOT passed directly here.
+          # Azure AD's Federated Credentials handle the authentication based on the OIDC token.
+          # We only need to provide the subscription-id to the login action.
+          azure-subscription: ${{ secrets.AZUREAPPSERVICE_SUBSCRIPTIONID_2893712FC95E4564961A934DD6F6ED75 }}
       - name: 'Deploy to Azure Web App'
         id: deploy-to-webapp
         uses: azure/webapps-deploy@v3


### PR DESCRIPTION
Understood. Here's the updated workflow file in English, incorporating the switch to OIDC authentication and removing the explicit client-id, tenant-id, and client-secret from the azure/login step.

YAML

# Docs for the Azure Web Apps Deploy action: https://github.com/Azure/webapps-deploy
# More GitHub Actions for Azure: https://github.com/Azure/actions

name: Build and deploy Node.js app to Azure Web App - mockinterviewapp-backend-takashi01

on:
  push:
    branches:
      - main workflow_dispatch:

jobs:
  build:
    runs-on: ubuntu-latest permissions: contents: read # This is required for actions/checkout steps:
      - uses: actions/checkout@v4
      - name: Set up Node.js version uses: actions/setup-node@v3 with: node-version: '18.x' # Set to 18.x to match your Azure App Service setting. You can test 22.x later if needed.

      - name: npm install, build, and test
        run: |
          npm install
          npm run build --if-present
          npm run test --if-present

      - name: Zip artifact for deployment
        run: |
          # Zip the contents of the current directory (your repo root)
          # This assumes package.json, server.js, node_modules etc., are at the root level of your Git repository.
          # Exclude the .git directory and the workflow files themselves from the zip
          zip -r release.zip . -x ".git/*" ".github/workflows/*"

      - name: Upload artifact for deployment job
        uses: actions/upload-artifact@v4
        with:
          name: node-app
          path: release.zip

  deploy:
    runs-on: ubuntu-latest needs: build environment: name: 'Production' # This environment name must exactly match the "GitHub environment name" you configured in Azure Federated Credentials. url: ${{ steps.deploy-to-webapp.outputs.webapp-url }} permissions: id-token: write # This permission is crucial for OpenID Connect (OIDC) authentication. contents: read steps:
      - name: Download artifact from build job uses: actions/download-artifact@v4 with: name: node-app
      - name: Unzip artifact for deployment run: unzip release.zip - name: Login to Azure uses: azure/login@v2 with: # For OIDC authentication (due to 'id-token: write' permission), # 'client-id', 'tenant-id', and 'client-secret' are NOT passed directly here. # Azure AD's Federated Credentials handle the authentication based on the OIDC token. # We only need to provide the subscription-id to the login action. azure-subscription: ${{ secrets.AZUREAPPSERVICE_SUBSCRIPTIONID_2893712FC95E4564961A934DD6F6ED75 }} - name: 'Deploy to Azure Web App' id: deploy-to-webapp uses: azure/webapps-deploy@v3 with: app-name: 'mockinterviewapp-backend-takashi01' slot-name: 'Production' package: . # Deploy the contents of the current directory (which is where the unzipped artifact resides) # Important: Ensure 'enable-oryx-build' and 'scm-do-build-during-deployment' are NOT present here. Crucial Steps After Updating This File:

Replace the File: Save this content as .github/workflows/main_mockinterviewapp-backend-takashi01.yml in your local repository, completely overwriting its current content.

Configure Federated Credentials in Azure Portal:

Go to Microsoft Entra ID -> App registrations -> Your app registration (e.g., mockinterviewapp-backend-deployment-newSP) -> Certificates & secrets -> Federated credentials. Add a new credential with the following details:
Scenario: GitHub Actions deploying Azure resources Organization: Your GitHub username (e.g., takashim0101) Repository: Your repository name (mock-interview-backend-nodejs-mongodb) Entity type: Environment
GitHub environment name: Production (This must match the name: 'Production' in your workflow's deploy job). Name: Give it a descriptive name (e.g., mockinterview-backend-oidc). Clean Up GitHub Secrets (Recommended):

Go to your GitHub repository's Settings -> Secrets and variables -> Actions. You can now safely delete the following secrets, as they are no longer used for OIDC authentication: AZUREAPPSERVICE_CLIENTID_DE95F72921FA45E9B291A5AD76BCD307 AZUREAPPSERVICE_TENANTID_3D8C02EEC437468194CDE7242E06C6E5 AZUREAPPSERVICE_CLIENT_SECRET
Keep AZUREAPPSERVICE_SUBSCRIPTIONID_2893712FC95E4564961A934DD6F6ED75, as it's still needed by the azure/login action. Commit and Push:

In your local repository, commit these changes and push them to the main branch: Bash

git add .github/workflows/main_mockinterviewapp-backend-takashi01.yml git commit -m "Refactor to use OIDC authentication for Azure login" git push origin main
Monitor GitHub Actions:

Go to your GitHub repository's "Actions" tab.
A new workflow run will be triggered. Click on it. Verify that the Login to Azure step in the deploy job now passes successfully, and that the deployment proceeds. This complete switch to OIDC authentication should resolve the persistent login errors you've been encountering.


Sources