### PR TITLE
Add example.env

### DIFF
--- a/example.env
+++ b/example.env
@@ -8,3 +8,9 @@ PORT=YOUR_PORT_NUM_HERE
 # DB_CONNECTION_STRING should be in the format: mongodb://<username>:<password>@<host>:<port>/<database_name>
 DB_CONNECTION_STRING=mongodb://<username>:<password>@<host>:<port>/<database_name>
 
+# Set NODE_ENV to 'production' when deploying to a production environment.
+# This helps frameworks like Express optimize performance and handle errors appropriately.
+
+
+
+


### PR DESCRIPTION
# Set NODE_ENV to 'production' when deploying to a production environment.
# This helps frameworks like Express optimize performance and handle errors appropriately.
NODE_ENV=development